### PR TITLE
画像リサイズLambdaの実装

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,36 @@
+import os
+from io import BytesIO
+
+import boto3
+from PIL import Image
+
+THUMBNAIL_SIZE = (128, 128)
+
+
+def handler(event, context, s3_client=None):
+    """Resize uploaded images and store thumbnails."""
+    s3 = s3_client or boto3.client("s3")
+    for record in event.get("Records", []):
+        bucket = record["s3"]["bucket"]["name"]
+        key = record["s3"]["object"]["key"]
+
+        if not key.lower().startswith("uploads/"):
+            continue
+
+        if not key.lower().endswith((".jpg", ".jpeg", ".png")):
+            continue
+
+        file_name = os.path.basename(key)
+        thumb_key = f"thumbnails/{file_name}"
+
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        image = Image.open(obj["Body"])
+        image.thumbnail(THUMBNAIL_SIZE)
+
+        buffer = BytesIO()
+        image.save(buffer, format=image.format)
+        buffer.seek(0)
+
+        s3.put_object(Bucket=bucket, Key=thumb_key, Body=buffer, ContentType=obj.get("ContentType"))
+
+    return {"statusCode": 200}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+pillow
+moto[s3]
+pytest

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from io import BytesIO
+
+import boto3
+from moto import mock_aws
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from lambda_function import handler, THUMBNAIL_SIZE
+
+
+@mock_aws
+def test_thumbnail_creation():
+    os.environ.setdefault('AWS_ACCESS_KEY_ID', 'testing')
+    os.environ.setdefault('AWS_SECRET_ACCESS_KEY', 'testing')
+    os.environ.setdefault('AWS_SESSION_TOKEN', 'testing')
+    os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+    s3 = boto3.client('s3')
+    bucket = 'test-bucket'
+    s3.create_bucket(Bucket=bucket)
+
+    # create sample image
+    img = Image.new('RGB', (500, 500), color='red')
+    buffer = BytesIO()
+    img.save(buffer, format='JPEG')
+    buffer.seek(0)
+    s3.put_object(Bucket=bucket, Key='uploads/test.jpg', Body=buffer.getvalue(), ContentType='image/jpeg')
+
+    event = {
+        'Records': [
+            {
+                's3': {
+                    'bucket': {'name': bucket},
+                    'object': {'key': 'uploads/test.jpg'}
+                }
+            }
+        ]
+    }
+
+    handler(event, None)
+
+    resp = s3.get_object(Bucket=bucket, Key='thumbnails/test.jpg')
+    thumb = Image.open(resp['Body'])
+    assert thumb.size[0] <= THUMBNAIL_SIZE[0]
+    assert thumb.size[1] <= THUMBNAIL_SIZE[1]


### PR DESCRIPTION
## 概要
- 画像アップロードイベントに応じてサムネイルを生成するLambda関数を追加
- Pillowを用いたリサイズ処理とS3への保存を実装
- motoを使ったユニットテストを整備

## テスト
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c7448ef88321a98d6a3d4673cd66