### PR TITLE
chore: ignore pytest cache and common Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Python
+__pycache__/
+*.py[cod]
+*.so
+.venv/
+venv/
+.env
+.env.*
+
+# pytest
+.pytest_cache/
+.cache/
+*.pytest_cache/
+
+# coverage
+.coverage
+htmlcov/
+
+# IDE
+.vscode/
+.idea/
+*.iml


### PR DESCRIPTION
このPRでは、pytestのキャッシュディレクトリ(.pytest_cache)とその他Python生成物を.gitignoreに追加しました。\n\n- pytest: .pytest_cache/, .cache/\n- Python: __pycache__/、*.py[cod] など\n- 仮想環境: .venv/, venv/\n- coverage: .coverage, htmlcov/\n- IDE: .vscode/, .idea/\n\nテストや開発時に不要なファイルがGitに含まれないようにします。